### PR TITLE
[Setting] 로그아웃 구현

### DIFF
--- a/lib/core/google_sign_in_helper.dart
+++ b/lib/core/google_sign_in_helper.dart
@@ -29,3 +29,12 @@ Future<UserCredential?> signInWithGoogle() async {
     return null;
   }
 }
+
+Future<void> signOutGoogle() async {
+  try {
+    await GoogleSignIn().signOut();
+    await FirebaseAuth.instance.signOut();
+  } catch (e) {
+    debugPrint('로그아웃 오류: $e');
+  }
+}

--- a/lib/ui/pages/setting/widgets/setting_actions_box.dart
+++ b/lib/ui/pages/setting/widgets/setting_actions_box.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:with_run_app/core/google_sign_in_helper.dart';
+import 'package:with_run_app/ui/pages/login/login_page.dart';
 
 class SettingActionBox extends StatelessWidget {
   const SettingActionBox({super.key});
@@ -25,10 +27,31 @@ class SettingActionBox extends StatelessWidget {
             leading: Icon(Icons.logout, color: Colors.red),
             title: Text("로그아웃"),
             trailing: Icon(Icons.arrow_forward_ios, size: 16),
-            onTap: () {},
+            onTap: () async {
+              _logout(context);
+            },
           ),
         ],
       ),
     );
+  }
+
+  void _logout(BuildContext context) async {
+    try {
+      await signOutGoogle();
+      Navigator.pushAndRemoveUntil(
+        context,
+        MaterialPageRoute(
+          builder: (context) {
+            return LoginPage();
+          },
+        ),
+        (route) => false,
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text('로그아웃 중 오류가 발생했습니다.')));
+    }
   }
 }


### PR DESCRIPTION
### 🚀 개요
로그아웃을 진행한다.

### 🔧 작업 내용
- 구글, Firebase 로그아웃 구현
- 스택에 있는 화면들을 제거하고 Login 화면으로 이동

### 실행 화면
<img src="https://github.com/user-attachments/assets/55ec5da6-cd56-4e27-b27c-dc9e794f3fbd" width="300" height="600"/>


### 💡issue : #58 