### PR TITLE
[Setting] 테마 변경에 따른 색상 설정

### DIFF
--- a/lib/ui/pages/setting/setting_page.dart
+++ b/lib/ui/pages/setting/setting_page.dart
@@ -7,26 +7,18 @@ class SettingPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+
     return Scaffold(
-      backgroundColor: Colors.pink[100],
+      backgroundColor: isDarkMode ? Colors.blue[900] : Colors.blue[100],
       extendBodyBehindAppBar: true,
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-      ),
+      appBar: AppBar(backgroundColor: Colors.transparent),
       body: Column(
         children: const [
-          Flexible(
-            flex: 3,
-            child: ProfileHeader(),
-          ),
-          Flexible(
-            flex: 6,
-            child: SettingBodyContainer(),
-          ),
+          Flexible(flex: 3, child: ProfileHeader()),
+          Flexible(flex: 6, child: SettingBodyContainer()),
         ],
       ),
     );
   }
 }
-

--- a/lib/ui/pages/setting/widgets/profile_header.dart
+++ b/lib/ui/pages/setting/widgets/profile_header.dart
@@ -30,15 +30,15 @@ class ProfileHeader extends ConsumerWidget {
           const SizedBox(height: 8),
           Text(
             user?.nickname ?? "닉네임 없음",
-            style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
           ),
           Text(
             firebaseUser?.displayName ?? "이름 없음",
-            style: TextStyle(fontSize: 16, color: Colors.grey[800]),
+            style: TextStyle(fontSize: 16, fontWeight:  FontWeight.bold),
           ),
           Text(
             firebaseUser?.email ?? "이메일 없음",
-            style: TextStyle(fontSize: 14, color: Colors.grey),
+            style: TextStyle(fontSize: 14, fontWeight:  FontWeight.bold),
           ),
         ],
       ),

--- a/lib/ui/pages/setting/widgets/setting_actions_box.dart
+++ b/lib/ui/pages/setting/widgets/setting_actions_box.dart
@@ -7,12 +7,18 @@ class SettingActionBox extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+
     return Container(
       padding: EdgeInsets.symmetric(vertical: 10),
       decoration: BoxDecoration(
-        color: Colors.white,
         borderRadius: BorderRadius.circular(16),
-        boxShadow: [BoxShadow(color: Colors.black12, blurRadius: 4)],
+        boxShadow: [
+          BoxShadow(
+            color: isDarkMode ? Colors.black : Colors.white,
+            blurRadius: 4,
+          ),
+        ],
       ),
       child: Column(
         children: [

--- a/lib/ui/pages/setting/widgets/setting_actions_box.dart
+++ b/lib/ui/pages/setting/widgets/setting_actions_box.dart
@@ -23,13 +23,6 @@ class SettingActionBox extends StatelessWidget {
       child: Column(
         children: [
           ListTile(
-            leading: Icon(Icons.dark_mode, color: Colors.blue),
-            title: Text("다크 모드 변환"),
-            trailing: Icon(Icons.arrow_forward_ios, size: 16),
-            onTap: () {},
-          ),
-          Divider(),
-          ListTile(
             leading: Icon(Icons.logout, color: Colors.red),
             title: Text("로그아웃"),
             trailing: Icon(Icons.arrow_forward_ios, size: 16),

--- a/lib/ui/pages/setting/widgets/setting_body_container.dart
+++ b/lib/ui/pages/setting/widgets/setting_body_container.dart
@@ -6,6 +6,8 @@ class SettingBodyContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isDarkMode = Theme.of(context).brightness == Brightness.dark;
+
     return Positioned(
       top: MediaQuery.of(context).size.height * 0.32,
       left: 0,
@@ -13,7 +15,7 @@ class SettingBodyContainer extends StatelessWidget {
       bottom: 0,
       child: Container(
         decoration: BoxDecoration(
-          color: Colors.grey[100],
+          color: isDarkMode ? Colors.grey[900] : Colors.grey[100],
           borderRadius: BorderRadius.only(
             topLeft: Radius.circular(48),
             topRight: Radius.circular(48),


### PR DESCRIPTION
### 🚀 개요
테마 변경에 따른 설정 화면의 위젯 색상을 변경한다.

### 🔧 작업 내용
- 배경색 설정
- 메뉴 컨테이너 설정
- 다크모드 변환 버튼 제거

### 실행 화면
<img src="https://github.com/user-attachments/assets/45aa26aa-7d0e-44b2-9938-4a52f688623c" width="300" height="600"/>
<img src="https://github.com/user-attachments/assets/c59da33e-2ef4-4e03-ab92-32b7fce05a46" width="300" height="600"/>

### 💡issue : #67 